### PR TITLE
deprecate SmartNoise-Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
+**Notice**: SmartNoise-Core is deprecated. Please migrate to the OpenDP library:
+- [OpenDP PyPi Package](https://pypi.org/project/opendp/)
+- [OpenDP GitHub Repo](https://github.com/opendp/opendp/)
+
+----------------------------------------------------
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8-blue)](https://www.python.org/)
 
-<a href="https://opendifferentialprivacy.github.io"><img src="https://raw.githubusercontent.com/opendifferentialprivacy/smartnoise-core/1b196bb1e375a9686ad6d44269036cf78a39fdf2/images/SmartNoise_Logos/SVG/LogoMark_color.svg" align="left" height="65" vspace="8" hspace="18"></a>
+<a href="https://opendp.org/"><img src="https://raw.githubusercontent.com/opendifferentialprivacy/smartnoise-core/1b196bb1e375a9686ad6d44269036cf78a39fdf2/images/SmartNoise_Logos/SVG/LogoMark_color.svg" align="left" height="65" vspace="8" hspace="18"></a>
 
 ## SmartNoise Core Differential Privacy Library Python Bindings 
 \
@@ -112,7 +118,7 @@ The binaries have been used on OS X and Ubuntu and are in the process of additio
 
 ### SmartNoise Core Documentation
 
-- [Python library documentation](https://opendp.github.io/smartnoise-core-python)
+- [Python library documentation](https://old-docs.smartnoise.org/)
 
 
 ## Communication

--- a/opendp/smartnoise/core/__init__.py
+++ b/opendp/smartnoise/core/__init__.py
@@ -4,8 +4,3 @@ from .base import *
 # components.py is generated from scripts/code_generation.py
 # in opendifferentialprivacy/smartnoise-core-python
 from opendp.smartnoise.core.components import *
-
-import os
-if os.environ.get('SN_ACKNOWLEDGE_DEPRECATION', 'false') == 'false':
-    import warnings
-    warnings.warn('SmartNoise-Core is deprecated. Please migrate to the OpenDP library instead: https://docs.opendp.org', DeprecationWarning)

--- a/opendp/smartnoise/core/__init__.py
+++ b/opendp/smartnoise/core/__init__.py
@@ -5,3 +5,7 @@ from .base import *
 # in opendifferentialprivacy/smartnoise-core-python
 from opendp.smartnoise.core.components import *
 
+import os
+if os.environ.get('SN_ACKNOWLEDGE_DEPRECATION', 'false') == 'false':
+    import warnings
+    warnings.warn('SmartNoise-Core is deprecated. Please migrate to the OpenDP library instead: https://docs.opendp.org', DeprecationWarning)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [metadata]
 name = opendp-smartnoise-core
-version = 0.2.2
+version = 0.2.3
 author = Consequences of Data
 author-email = smartnoise@opendp.org
-home-page = https://github.com/opendifferentialprivacy/smartnoise-core-python
+home-page = https://github.com/opendp/smartnoise-core-python
 description = a pluggable library of differentially private algorithms and mechanisms for releasing privacy preserving queries and statistics
 long-description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup
 import os
 
+import warnings
+warnings.warn('SmartNoise-Core is deprecated. Please migrate to the OpenDP library instead: https://docs.opendp.org', DeprecationWarning)
+
 setup(
     extras_require={
         "plotting": [


### PR DESCRIPTION
Closes #68 

**Notice**: SmartNoise-Core is deprecated. Please migrate to the OpenDP library:
- [OpenDP PyPi Package](https://pypi.org/project/opendp/)
- [OpenDP GitHub Repo](https://github.com/opendp/opendp/)
